### PR TITLE
Update to 1.19.4 + Bonus feature

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,14 +2,14 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.19.3
-yarn_mappings=1.19.3+build.5
-loader_version=0.14.14
+minecraft_version=1.19.4
+yarn_mappings=1.19.4+build.1
+loader_version=0.14.17
 # Mod Properties
 mod_version=2.0.0
 maven_group=amymialee
 archives_base_name=visible-barriers
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.73.2+1.19.3
+fabric_version=0.76.0+1.19.4
 mixin_extras_version=0.2.0-beta.3

--- a/src/main/java/xyz/amymialee/visiblebarriers/mixin/MarkerEntityMixin.java
+++ b/src/main/java/xyz/amymialee/visiblebarriers/mixin/MarkerEntityMixin.java
@@ -3,7 +3,7 @@ package xyz.amymialee.visiblebarriers.mixin;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.MarkerEntity;
-import net.minecraft.network.Packet;
+import net.minecraft.network.packet.Packet;
 import net.minecraft.network.packet.s2c.play.EntitySpawnS2CPacket;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;

--- a/src/main/java/xyz/amymialee/visiblebarriers/mixin/boxing/BlockMixin.java
+++ b/src/main/java/xyz/amymialee/visiblebarriers/mixin/boxing/BlockMixin.java
@@ -15,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class BlockMixin extends AbstractBlockMixin {
     @Shadow public abstract BlockState getDefaultState();
 
-    @Inject(method = "isTranslucent", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "isTransparent", at = @At("HEAD"), cancellable = true)
     public void visibleBarriers$isTranslucent(BlockState state, BlockView world, BlockPos pos, CallbackInfoReturnable<Boolean> cir) {}
 
     @Inject(method = "getPlacementState", at = @At("HEAD"), cancellable = true)

--- a/src/main/java/xyz/amymialee/visiblebarriers/mixin/client/DisplayContextMixin.java
+++ b/src/main/java/xyz/amymialee/visiblebarriers/mixin/client/DisplayContextMixin.java
@@ -1,0 +1,17 @@
+package xyz.amymialee.visiblebarriers.mixin.client;
+
+import net.minecraft.item.ItemGroup;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ItemGroup.DisplayContext.class)
+public class DisplayContextMixin {
+
+    @Inject(method = "hasPermissions", at = @At("HEAD"), cancellable = true)
+    public void visibleBarriers$overridePermission(CallbackInfoReturnable<Boolean> cir) {
+        cir.setReturnValue(true);
+        cir.cancel();
+    }
+}

--- a/src/main/java/xyz/amymialee/visiblebarriers/util/FloatyRenderer.java
+++ b/src/main/java/xyz/amymialee/visiblebarriers/util/FloatyRenderer.java
@@ -4,7 +4,7 @@ import net.minecraft.client.render.OverlayTexture;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.item.ItemRenderer;
 import net.minecraft.client.render.model.BakedModel;
-import net.minecraft.client.render.model.json.ModelTransformation;
+import net.minecraft.client.render.model.json.ModelTransformationMode;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
@@ -28,7 +28,7 @@ public class FloatyRenderer<T extends Entity> {
         BakedModel bakedModel = this.renderer.getModel(stack, entity.world, null, entity.getId());
         matrixStack.translate(0.0D, entity.getHeight() / 2, 0.0D);
         matrixStack.multiply(RotationAxis.POSITIVE_Y.rotation(-((entity.age + g) * 8) / 20.0f));
-        this.renderer.renderItem(stack, ModelTransformation.Mode.GROUND, false, matrixStack, vertexConsumerProvider, i, OverlayTexture.DEFAULT_UV, bakedModel);
+        this.renderer.renderItem(stack, ModelTransformationMode.GROUND, false, matrixStack, vertexConsumerProvider, i, OverlayTexture.DEFAULT_UV, bakedModel);
         matrixStack.pop();
     }
 

--- a/src/main/resources/visiblebarriers.mixins.json
+++ b/src/main/resources/visiblebarriers.mixins.json
@@ -25,7 +25,8 @@
     "client.ItemStackMixin",
     "client.LightBlockMixin",
     "client.LightmapTextureManagerMixin",
-    "client.MouseMixin"
+    "client.MouseMixin",
+    "client.DisplayContextMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Updates the mod to 1.19.4.
Additionally, adds an extra mixin to `ItemGroup.DisplayContext` class to make the Operator Items Tab always show up regardless of the player permission (to make the operator tab work like the special items tab in 1.19.2 and earlier)